### PR TITLE
Fixing missing LeakCanary dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# leakcanaryTest
+
+
+a test app for this issue 
+
+https://github.com/square/leakcanary/issues/2515

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     androidTestImplementation "com.squareup.leakcanary:leakcanary-android-instrumentation:2.10"
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.5.0'


### PR DESCRIPTION
Once I add this, running `./gradlew app:connectedDebugAndroidTest` will actually run the test (which fails, but for normal UI test failure reasons).